### PR TITLE
Accept email on exists method

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,12 @@ account = api.accounts.show("MPA-12312312312")
 
 ### Verifica se usuário já possui Conta Moip
 ```ruby
-api.accounts.exists?("123.456.789.10")
+api.accounts.exists?({tax_document: "123.456.789.10"})
+```
+
+### ou
+```ruby
+api.accounts.exists?({email: "dev.moip@labs.moip.com.br"})
 ```
 
 ## Conta bancária
@@ -707,4 +712,4 @@ end
 
 ## Comunidade Slack [![Slack](https://user-images.githubusercontent.com/4432322/37355972-ba0e9f32-26c3-11e8-93d3-39917eb24109.png)](https://slackin-cqtchmfquq.now.sh)
 
-Tem dúvidas? Fale com a gente no [Slack](https://slackin-cqtchmfquq.now.sh/)! 
+Tem dúvidas? Fale com a gente no [Slack](https://slackin-cqtchmfquq.now.sh/)!

--- a/examples/marketplace/create-classical-account-company.rb
+++ b/examples/marketplace/create-classical-account-company.rb
@@ -7,10 +7,12 @@ client = Moip2::Client.new(:sandbox, auth)
 api = Moip2::Api.new(client)
 
 # Check if account exists
-api.accounts.exists?("978.443.610-85")
+api.accounts.exists?({tax_document: "978.443.610-85"})
+
+# or
+api.accounts.exists?({email: "dev.moip@labs.moip.com.br"})
 
 # Create account
-
 account = api.accounts.create(
   email: {
     address: "dev.moip@labs.moip.com.br",

--- a/examples/marketplace/create-classical-account-without-company.rb
+++ b/examples/marketplace/create-classical-account-without-company.rb
@@ -7,7 +7,10 @@ client = Moip2::Client.new(:sandbox, auth)
 api = Moip2::Api.new(client)
 
 # Check if account exists
-api.accounts.exists?("978.443.610-85")
+api.accounts.exists?({tax_document: "978.443.610-85"})
+
+# or
+api.accounts.exists?({email: "dev.moip@labs.moip.com.br"})
 
 # Create account
 account = api.accounts.create(

--- a/lib/moip2/accounts_api.rb
+++ b/lib/moip2/accounts_api.rb
@@ -14,14 +14,26 @@ module Moip2
       Resource::Account.new client, client.post(base_path, account)
     end
 
-    def exists?(tax_document)
-      response = client.get("#{base_path}/exists?tax_document=#{tax_document}")
+    def exists?(data)
+      raise "Use: {email: 'dev@moip.com'} or {tax_document: '999.999.999-99'}" unless has_attribute_to_search(data)
+
+      response = client.get("#{base_path}/exists?#{to_search(data)}")
 
       response.success?
     end
 
     def show(id)
       Resource::Account.new client, client.get("#{base_path}/#{id}")
+    end
+
+    private
+
+    def has_attribute_to_search(data)
+      data.key?(:tax_document) || data.key?(:email)
+    end
+
+    def to_search(data)
+      data.key?(:tax_document) ? "tax_document=#{data[:tax_document]}" : "email=#{data[:email]}"
     end
   end
 end

--- a/spec/moip2/accounts_api_spec.rb
+++ b/spec/moip2/accounts_api_spec.rb
@@ -144,8 +144,8 @@ describe Moip2::AccountsApi do
   describe "#exists" do
     describe "with a registered tax document" do
       let(:existence_check) do
-        VCR.use_cassette("account_exists") do
-          accounts_api.exists?("436.130.670-21")
+        VCR.use_cassette("account_exists_for_tax_document") do
+          accounts_api.exists?({tax_document: "436.130.670-21"})
         end
       end
 
@@ -154,8 +154,28 @@ describe Moip2::AccountsApi do
 
     describe "with a non registered tax document" do
       let(:existence_check) do
-        VCR.use_cassette("account_doesnt_exist") do
-          accounts_api.exists?("555.000.123-40")
+        VCR.use_cassette("account_doesnt_exist_for_tax_document") do
+          accounts_api.exists?({tax_document: "555.000.123-40"})
+        end
+      end
+
+      it { expect(existence_check).to be false }
+    end
+
+    describe "with a registered email" do
+      let(:existence_check) do
+        VCR.use_cassette("account_exists_for_email") do
+          accounts_api.exists?({email: "dev.moip.1503312536@labs.moip.com.br"})
+        end
+      end
+
+      it { expect(existence_check).to be true }
+    end
+
+    describe "with a non registered email" do
+      let(:existence_check) do
+        VCR.use_cassette("account_doesnt_exist_for_email") do
+          accounts_api.exists?({email: "dev.moip.0123456789@labs.moip.com.br"})
         end
       end
 

--- a/vcr_cassettes/account_doesnt_exist_for_email.yml
+++ b/vcr_cassettes/account_doesnt_exist_for_email.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox.moip.com.br/v2/accounts/exists?email=dev.moip.0123456789@labs.moip.com.br
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 9fdc242631454d4c95d82e27b4127394_v2
+      User-Agent:
+      - MoipRubySDK/0.1.5 (+https://github.com/moip/moip-sdk-ruby)
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 22 Aug 2017 12:51:11 GMT
+      Server:
+      - nginx/1.6.3
+      Status:
+      - 400 Bad Request
+      Content-Type:
+      - application/json
+      X-Newrelic-App-Data:
+      - PxQFUlBXAQoTVVBRBAkAX1MTGhEhCQ0WQg1UDl1KG3VBBEkEHiBjK14MdhEPTk4BHwUCAVhEWRIXHlNLCxUXERBKfydsERYeA0sJTQFPA1JWAwdRVlYPAQJUVVcPCA9SUB0bAk5EBlRTAFlTCFpXAwUGWAJXWRE/
+      Content-Length:
+      - '3'
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - Origin
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '400'
+    http_version: 
+  recorded_at: Tue, 22 Aug 2017 12:51:11 GMT
+recorded_with: VCR 2.9.3

--- a/vcr_cassettes/account_doesnt_exist_for_tax_document.yml
+++ b/vcr_cassettes/account_doesnt_exist_for_tax_document.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox.moip.com.br/v2/accounts/exists?tax_document=555.000.123-40
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 9fdc242631454d4c95d82e27b4127394_v2
+      User-Agent:
+      - MoipRubySDK/0.1.5 (+https://github.com/moip/moip-sdk-ruby)
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 22 Aug 2017 12:51:11 GMT
+      Server:
+      - nginx/1.6.3
+      Status:
+      - 400 Bad Request
+      Content-Type:
+      - application/json
+      X-Newrelic-App-Data:
+      - PxQFUlBXAQoTVVBRBAkAX1MTGhEhCQ0WQg1UDl1KG3VBBEkEHiBjK14MdhEPTk4BHwUCAVhEWRIXHlNLCxUXERBKfydsERYeA0sJTQFPA1JWAwdRVlYPAQJUVVcPCA9SUB0bAk5EBlRTAFlTCFpXAwUGWAJXWRE/
+      Content-Length:
+      - '3'
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - Origin
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '400'
+    http_version: 
+  recorded_at: Tue, 22 Aug 2017 12:51:11 GMT
+recorded_with: VCR 2.9.3

--- a/vcr_cassettes/account_exists_for_email.yml
+++ b/vcr_cassettes/account_exists_for_email.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox.moip.com.br/v2/accounts/exists?email=dev.moip.1503312536@labs.moip.com.br
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 9fdc242631454d4c95d82e27b4127394_v2
+      User-Agent:
+      - MoipRubySDK/0.1.5 (+https://github.com/moip/moip-sdk-ruby)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 22 Aug 2017 12:51:09 GMT
+      Server:
+      - nginx/1.6.3
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json
+      X-Newrelic-App-Data:
+      - PxQFUlBXAQoTVVBRBAkAX1MTGhEhCQ0WQg1UDl1KG3VBBEkEHiBjK14MdhEPTk4BHwUCAVhEWRIXHlNLCxUXERBKfydsERYeA0sJTQFPBlZXAwBQUVIIBghSVFYACBtLVR0UBwRVUFAHVA9WDw8HAABWCkNs
+      Expires:
+      - Wed, 22 Aug 2018 12:51:09 GMT
+      Cache-Control:
+      - max-age=31536000, public
+      Content-Length:
+      - '3'
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '200'
+    http_version: 
+  recorded_at: Tue, 22 Aug 2017 12:51:10 GMT
+recorded_with: VCR 2.9.3

--- a/vcr_cassettes/account_exists_for_tax_document.yml
+++ b/vcr_cassettes/account_exists_for_tax_document.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox.moip.com.br/v2/accounts/exists?tax_document=436.130.670-21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 9fdc242631454d4c95d82e27b4127394_v2
+      User-Agent:
+      - MoipRubySDK/0.1.5 (+https://github.com/moip/moip-sdk-ruby)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 22 Aug 2017 12:51:09 GMT
+      Server:
+      - nginx/1.6.3
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json
+      X-Newrelic-App-Data:
+      - PxQFUlBXAQoTVVBRBAkAX1MTGhEhCQ0WQg1UDl1KG3VBBEkEHiBjK14MdhEPTk4BHwUCAVhEWRIXHlNLCxUXERBKfydsERYeA0sJTQFPBlZXAwBQUVIIBghSVFYACBtLVR0UBwRVUFAHVA9WDw8HAABWCkNs
+      Expires:
+      - Wed, 22 Aug 2018 12:51:09 GMT
+      Cache-Control:
+      - max-age=31536000, public
+      Content-Length:
+      - '3'
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - Origin
+    body:
+      encoding: UTF-8
+      string: '200'
+    http_version: 
+  recorded_at: Tue, 22 Aug 2017 12:51:10 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
## Changed `exists?` method to accept a hash with `email` or `tax_document` as parameter.

## Detailed description
  #### Example:
  - Created `to_search` method on `accounts_api.rb` to decided what parameter will be used
  - Created `has_attribute_to_search` method on `accounts_api.rb` to check if in hash has some accepted attribute
  - Changed `exists?` method to receive a hash, instead a document as string

## Checklist
  - [x] Added tests
  - [x] All existing and new tests pass
  - [x] Updated README (if appropriate)
  - [x] Code lints (Rubocop) successfully
  - [x] Commits are according to our commit guidelines
