### PR TITLE
Allow params for entries request (optional)

### DIFF
--- a/lib/moip2/entry_api.rb
+++ b/lib/moip2/entry_api.rb
@@ -14,8 +14,8 @@ module Moip2
       Resource::Entry.new client, client.get("#{base_path}/#{id}")
     end
 
-    def find_all
-      Resource::Entry.new client, client.get("#{base_path}")
+    def find_all(params = {})
+      Resource::Entry.new client, client.get("#{base_path}?#{params.to_query}")
     end
   end
 end


### PR DESCRIPTION
Just allow to use LIMIT and OFFSET parameters for `entries` request as described on API docs: https://dev.wirecard.com.br/v2.0/reference#listar-todos-lan%C3%A7amentos

Without this it's impossible to get more than 20 entries through this SDK.